### PR TITLE
terminado 0.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.4" %}
+{% set version = "0.13.1" %}
 
 package:
   name: terminado
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/terminado/terminado-{{ version }}.tar.gz
-  sha256: 9a7dbcfbc2778830eeb70261bf7aa9d98a3eac8631a3afe3febeb57c12f798be
+  sha256: 5b82b5c6e991f0705a76f961f43262a7fb1e55b093c16dca83f16384a7f39b7b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - ptyprocess  # [not win]
+    - ptyprocess        # [not win]
     - pywinpty >=1.1.0  # [win]
     - tornado >=4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,54 +1,49 @@
+{% set name = "terminado" %}
 {% set version = "0.13.1" %}
 
 package:
-  name: terminado
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/t/terminado/terminado-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/terminado-{{ version }}.tar.gz
   sha256: 5b82b5c6e991f0705a76f961f43262a7fb1e55b093c16dca83f16384a7f39b7b
 
 build:
   number: 0
-  script: "{{ PYTHON }} setup.py install"
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - python
+    - flit
+    - pip
     - setuptools
-    - ptyprocess  # [not win]
-    - pywinpty  # [win]
     - tornado >=4
+    - wheel
   run:
     - python
     - ptyprocess  # [not win]
-    - pywinpty  # [win]
+    - pywinpty >=1.1  # [win]
     - tornado >=4
 
 test:
+  requires:
+    - pip
+    - posix  # [win]
+    - pytest
+    - pytest-cov
   imports:
     - terminado
-
-  requires:
-    - nose
-    - posix  # [win]
-
   commands:
-    - nosetests terminado  # [not (osx or win)]
-    # Failing test on osx: https://github.com/conda-forge/staged-recipes/pull/313#issuecomment-208426267
-    # Failing test on Linux (due to ps1 of conda? having conda activate in bashrc? One of those two!
-    # File "/home/ray/m/conda-bld/terminado_1503494513344/_test_env_placehold_.../lib/python2.7/site-packages/terminado/tests/basic_test.py", line 84, in get_pid
-    # ..
-    # self.write_stdin("echo $$\r")
-    # (stdout, extra) = yield self.read_stdout()
-    # pid = int(stdout.split('\n')[1])
-    # ..
-    #  ValueError: invalid literal for int() with base 10: '\x1b]777;notify;Command completed;echo $$\x07\x1b]0;ray@localhost:~/m/conda-bld/terminado_1503494513344/test_tmp\x07\x1b]7;file://localhost.localdomain/home/ray/m/conda-bld/terminado_1503494513344/test_tmp\x07(root) ec'
-    #- nosetests terminado  # [not osx and not linux]
+    # see run_test.py for more
+    - pip check
 
 about:
   home: https://github.com/jupyter/terminado
   license: BSD-2-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: Terminals served by tornado websockets
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ test:
   downstreams:
     - jupyter_server
     # notebook >=6.4.6 need to be rebuild for python 3.10 support
-    #- notebook
+    - notebook  # [not py310]
 
 about:
   home: https://github.com/jupyter/terminado

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,8 @@ test:
   # Testing them to verify that they will succeed
   downstreams:
     - jupyter_server
-    - notebook
+    # notebook >=6.4.6 need to be rebuild for python 3.10 support
+    #- notebook
 
 about:
   home: https://github.com/jupyter/terminado

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,13 +19,13 @@ requirements:
     - python
     - flit
     - pip
-    - setuptools
-    - tornado >=4
+    - setuptools >=40.8.0
+    - tornado
     - wheel
   run:
     - python
     - ptyprocess  # [not win]
-    - pywinpty >=1.1  # [win]
+    - pywinpty >=1.1.0  # [win]
     - tornado >=4
 
 test:
@@ -39,6 +39,11 @@ test:
   commands:
     # see run_test.py for more
     - pip check
+  # Downstream packages are jupyter_server and notebook
+  # Testing them to verify that they will succeed
+  downstreams:
+    - jupyter_server
+    - notebook
 
 about:
   home: https://github.com/jupyter/terminado

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,51 @@
+""" run terminado tests with pytest, including platform- and python-based skips
+    this is needed because `--pyargs` is not compatible with `-k` for
+    function/method-based names
+"""
+import os
+import sys
+import pkgutil
+import subprocess
+
+platform = sys.platform
+target_platform = os.environ["target_platform"]
+py_major = sys.version_info[:2]
+pypy = "__pypy__" in sys.builtin_module_names
+
+loader = pkgutil.get_loader("terminado.tests")
+test_path = os.path.dirname(loader.path)
+pytest = [sys.executable, "-m", "pytest"]
+pytest_args = [test_path, "-vv"]
+
+if not pypy:
+    pytest_args += ["--cov", "terminado", "--no-cov-on-fail"]
+
+
+skips = []
+
+# flaky tests
+if platform != "linux":
+    skips += [
+        "basic_command",
+        "max_terminals",
+        "namespace",
+        "single_process",
+        "unique_processes"
+    ]
+
+if "aarch64" in target_platform:
+    skips += ["max_terminals"]
+
+if not skips:
+    print("all tests will be run", flush=True)
+
+elif len(skips) == 1:
+    pytest_args += ["-k", "not {}".format(*skips)]
+else:
+    pytest_args += ["-k", "not ({})".format(" or ".join(skips))]
+
+print("Final pytest args for", platform, target_platform, py_major)
+print(" ".join([*pytest, *pytest_args]), flush=True)
+
+# actually run the tests
+sys.exit(subprocess.call([*pytest, *pytest_args]))


### PR DESCRIPTION
Update terminado to 0.13.1

Version change: bump version number from 0.9.4 to 0.13.1
Bug Tracker: new open issues https://github.com/takluyver/terminado/issues
Github releases:  https://github.com/takluyver/terminado/releases
Upstream license:  License file:  https://github.com/takluyver/terminado/blob/master/LICENSE
Upstream Changelog: https://github.com/takluyver/terminado/blob/main/CHANGELOG.md
Upstream setup.cfg:  https://github.com/jupyter/terminado/blob/v0.13.1/setup.cfg
Upstream setup.py:  https://github.com/takluyver/terminado/blob/v0.13.1/setup.py
Upstream pyproject.toml:  https://github.com/jupyter/terminado/blob/v0.13.1/pyproject.toml

The package terminado is mentioned inside the packages:
jupyter_server | notebook |

Actions:
1. Use jinja2 templates for source/url
2. Skip `py<37`
3. Update the script command
4. Update host dependencies
5. Use `pywinpty >=1.1.0  # [win]` in `run`
6. Update tests:
- add `run_test.py`
- use `pip check`
-  testing `downstream` package `jupyter_server`
7. Add `license_family`

Result:
- all-succeeded
